### PR TITLE
Support for custom events

### DIFF
--- a/src/services/emailSender.ts
+++ b/src/services/emailSender.ts
@@ -232,7 +232,7 @@ class EmailSenderService extends NotificationService {
 				};
 			}
 			default: {
-				return {};
+				return eventData;
 			}
 		}
 	}


### PR DESCRIPTION
By returning default event data, we can have this option for users to have any type of event and data. Docs can be updated to convey that 'to' is needed to provide receiver email address.

This is my first PR ever, so forgive me if I have made any mistake in drafting it.